### PR TITLE
action-wird-nicht-korrekt-im-toc-eingebunden #4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -531,7 +531,7 @@
         <root.build.outputPath>${project.build.directory}/webapp</root.build.outputPath>
         <js.build.outputPath>${root.build.outputPath}/js</js.build.outputPath>
 
-        <mapapps.version>4.14.3</mapapps.version>
+        <mapapps.version>4.15.1</mapapps.version>
         <!-- JS lib versions -->
         <apprt.version>${mapapps.version}</apprt.version>
         <!-- java lib versions -->

--- a/src/main/js/bundles/dn_tocactiondatatable/DatatableActionDefinitionFactory.js
+++ b/src/main/js/bundles/dn_tocactiondatatable/DatatableActionDefinitionFactory.js
@@ -39,8 +39,8 @@ export default class DatatableActionDefinitionFactory {
                 const ref = tocItem.ref;
                 const parent = ref && ref.parent;
                 const capabilities = parent && parent.capabilities;
-                if (ref && ref.type !== "group") {
-                    if (ref.type === "feature") {
+                if (ref && ref.sourceJSON?.type !== "Group Layer" && ref.type !== "group") {
+                    if (ref.sourceJSON?.type === "Feature Layer" || ref.type === "feature") {
                         return true;
                     } else if (capabilities?.operations?.supportsQuery) {
                         return true;
@@ -55,8 +55,8 @@ export default class DatatableActionDefinitionFactory {
             trigger(tocItem) {
                 const ref = tocItem.ref;
                 let id = ref.id;
-                if (ref?.parent?.type === "map-image") {
-                    id = ref.parent.id + "/" + ref.id;
+                if (ref?.layer?.type === "map-image") {
+                    id = ref.layer.id + "/" + ref.id;
                 }
                 const storeProps = {
                     id: "action_store_" + new Date().getTime(),


### PR DESCRIPTION
Mit dieser Änderung sollte der Fehler behoben sein. Er stellt sicher, dass bei Group Layern die Action nicht angezeigt wird und stellt sicher, dass er bei Feature Layern angezeigt wird. 

Außerdem unterstützt er nun wenn der Feature Layer unter mehreren Gruppen LAyern steht anstatt nur unter einem